### PR TITLE
Add site name to page title

### DIFF
--- a/web_modules/layouts/Page/index.js
+++ b/web_modules/layouts/Page/index.js
@@ -48,7 +48,10 @@ class Page extends Component {
 
     const htmlAttributes = { lang: "ja" }
 
-    const metaTitle = head.metaTitle ? head.metaTitle : head.title
+    const metaTitle = [
+      head.metaTitle ? head.metaTitle : head.title,
+      pkg.name,
+    ].join(" | ")
 
     const meta = [
       { property: "og:type", content: "article" },


### PR DESCRIPTION
# 目的
ページタイトルを
`ページ名 | サイト名`
にする。

区切りは` | `にするか` - `、サイト名が先か後かについては、検討が必要かもしれない