### PR TITLE
lgtmの機能を削除する

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 2
-pattern = "(?i):shipit:|:\\+1:|LGTM"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,0 @@
-trkw
-miyaoka


### PR DESCRIPTION
https://lgtm.co

上記機能です。
phenomic公式でもlgtm.coの機能を削除しているようです。
理由としてはGitHubのreview機能を利用するため。

https://github.com/trkw/trkw/issues/88