### PR TITLE
Add next/prev navigation to post

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-dom": "^0.14.0 || ^15.3.1",
     "react-ga": "^2.1.1",
     "react-helmet": "^3.0.0",
+    "react-icons": "^2.2.1",
     "react-redux": "^4.0.0",
     "react-router": "^2.3.0",
     "react-social-sharebuttons": "trkw/react-social-sharebuttons",

--- a/web_modules/Footer/index.css
+++ b/web_modules/Footer/index.css
@@ -1,5 +1,5 @@
 .footer {
-  margin: 80px auto 0;
+  margin: 0 auto;
   padding: 120px 0 80px;
   font-size: 0.75rem;
   text-align: center;

--- a/web_modules/layouts/Post/Post.js
+++ b/web_modules/layouts/Post/Post.js
@@ -1,0 +1,152 @@
+import React, { Component, PropTypes } from "react"
+import Page from "../Page"
+import styles from "./index.css"
+import moment from "moment"
+import Link from "react-router/lib/Link"
+import FaChevronRight from "react-icons/fa/chevron-right"
+import FaChevronLeft from "react-icons/fa/chevron-left"
+import {
+  FacebookButton,
+  TwitterTweetButton,
+  HatenabookmarkButton,
+  PocketButton,
+} from "react-social-sharebuttons"
+
+class Post extends Component {
+
+  // it's up to you to choose what to do with this layout ;)
+  isBrowser() {
+    return !(typeof document === "undefined" || typeof window === "undefined")
+  }
+
+  render() {
+    const { props } = this
+    const { head, navigation } = props
+    console.log(navigation)
+
+    const pageDate = moment(head.date ? new Date(head.date) : null)
+    const coverDir = "/assets/thumbnail/"
+
+    const authors = head.authors ? head.authors.join(",") : undefined
+
+    let url = ""
+
+    if (this.isBrowser()) {
+      url = window.location.href
+    }
+
+    const appId = "972356726110615"
+    const layout = "button_count"
+    const hatenaLayout = "standard-balloon"
+
+    return (
+      <Page
+        { ...props }
+        header={
+          <header className={ styles.header }>
+          {
+            pageDate &&
+            <time
+              className={ styles.date }
+              key={ pageDate.toISOString() }
+            >
+              { pageDate.locale("ja").format("YYYY/MM/DD dddd") }
+            </time>
+          }
+          {
+            <div
+              className={ styles.authors }
+            >
+              { authors }
+            </div>
+          }
+          {
+            head.image &&
+            <img
+              src={ coverDir + head.image }
+              className={ styles.cover }
+            />
+          }
+          </header>
+        }
+        footer={
+          <footer>
+            <ul className={ styles.sns }>
+              <li>
+                <FacebookButton
+                  url={ url }
+                  layout={ layout }
+                  appId={ appId }
+                />
+              </li>
+              <li>
+                <TwitterTweetButton
+                  text={ head.title }
+                />
+              </li>
+              <li><PocketButton /></li>
+              <li>
+                <HatenabookmarkButton
+                  url={ url }
+                  layout={ hatenaLayout }
+                />
+              </li>
+            </ul>
+            <nav>
+              <ul className={ styles.paging }>
+                <li className={ styles.paging__container }>
+                {
+                  navigation.next &&
+                  <div className={ styles.paging__item }>
+                    <div className={ styles.paging__item__header }>
+                      { "Newer" }
+                    </div>
+                    <FaChevronLeft
+                      className={ styles.paging__item__arrow }
+                    />
+                    <Link
+                      to={ navigation.next.__url }
+                      className={ styles.paging__item__anchor }
+                    >
+                      { navigation.next.title }
+                    </Link>
+                  </div>
+                }
+                </li>
+                <li className={ styles.paging__container }>
+                {
+                  navigation.previous &&
+                  <div className={ styles.paging__item }>
+                    <div className={ styles.paging__item__header }>
+                      { "Older" }
+                    </div>
+                    <FaChevronRight
+                      className={ styles.paging__item__arrow }
+                    />
+                    <Link
+                      to={ navigation.previous.__url }
+                      className={ styles.paging__item__anchor }
+                    >
+                      { navigation.previous.title }
+                    </Link>
+                  </div>
+                }
+                </li>
+              </ul>
+            </nav>
+          </footer>
+        }
+      />
+    )
+  }
+}
+
+Post.propTypes = {
+  head: PropTypes.object.isRequired,
+  navigation: PropTypes.shape({
+    next: PropTypes.object,
+    previous: PropTypes.object,
+  }).isRequired,
+}
+
+export default Post

--- a/web_modules/layouts/Post/index.css
+++ b/web_modules/layouts/Post/index.css
@@ -30,3 +30,93 @@
     margin: 5px 5px 0;
   }
 }
+
+.paging {
+  display: flex;
+  padding: 0;
+  margin: 0;
+
+  @media (max-width: 720px) {
+    flex-flow: column nowrap;
+  }
+  &__container {
+    width: 50%;
+    display: flex;
+    background: #ddd;
+    position: relative;
+
+    &:last-of-type {
+      border-left: 1px solid #666;
+
+      .paging__item__arrow {
+        left: auto;
+        right: 0;
+      }
+
+      @media (max-width: 720px) {
+        border-left: none;
+        border-top: 1px solid #666;
+      }
+    }
+
+    @media (max-width: 720px) {
+      width: 100%;
+    }
+  }
+  &__item {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    background: #333;
+
+    &__header {
+      position: absolute;
+      top: 10px;
+      left: 0;
+      right: 0;
+      margin: auto;
+      display: block;
+      text-align: center;
+      color: #fff;
+      font-size: 12px;
+      pointer-events: none;
+    }
+
+    &__arrow {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      margin: auto;
+      display: block;
+      text-align: center;
+      color: #fff;
+      font-size: 40px;
+      pointer-events: none;
+    }
+
+    &__anchor {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      height: 100%;
+      text-decoration: none;
+
+      padding: 40px 40px 20px;
+      transition: 0.1s ease-out;
+      background: linear-gradient(to bottom, #333 50%, #ff4081 50%);
+      background-size: 100% 200%;
+      background-position: top;
+
+      @media (max-width: 720px) {
+        padding: 30px 40px 10px;
+      }
+      &:hover {
+        color: #fff;
+        opacity: 1;
+        background-position: bottom;
+      }
+    }
+  }
+}

--- a/web_modules/layouts/Post/index.js
+++ b/web_modules/layouts/Post/index.js
@@ -1,102 +1,44 @@
 import React, { Component, PropTypes } from "react"
-import Page from "../Page"
-import styles from "./index.css"
-import moment from "moment"
-import {
-  FacebookButton,
-  TwitterTweetButton,
-  HatenabookmarkButton,
-  PocketButton,
-} from "react-social-sharebuttons"
+import Post from "./Post"
+import enhanceCollection from "phenomic/lib/enhance-collection"
 
-class Post extends Component {
+export default class PostAddNavigation extends Component {
+  static propTypes = {
+    __filename: PropTypes.string.isRequired,
+  };
 
-  // it's up to you to choose what to do with this layout ;)
+  static contextTypes = {
+    collection: PropTypes.array.isRequired,
+  };
 
-  isBrowser() {
-    return !(typeof document === "undefined" || typeof window === "undefined")
+  get postNavigation() {
+    const collection = enhanceCollection(this.context.collection, {
+      filter: (post) => {
+        if (process.env.NODE_ENV !== "production") {
+          return (post.layout === "Post")
+        }
+        else {
+          return (post.layout === "Post" && post.draft === undefined)
+        }
+      },
+      sort: "date",
+      addSiblingReferences: true,
+    })
+    const currentPost = collection
+      .find((item) => item.__filename === this.props.__filename)
+
+    return {
+      next: currentPost.next,
+      previous: currentPost.previous,
+    }
   }
 
   render() {
-    const { props } = this
-    const { head } = props
-
-    const pageDate = moment(head.date ? new Date(head.date) : null)
-    const coverDir = "/assets/thumbnail/"
-
-    const authors = head.authors ? head.authors.join(",") : undefined
-
-    let url = ""
-
-    if (this.isBrowser()) {
-      url = window.location.href
-    }
-
-    const appId = "972356726110615"
-    const layout = "button_count"
-    const hatenaLayout = "standard-balloon"
-
     return (
-      <Page
-        { ...props }
-        header={
-          <header className={ styles.header }>
-          {
-            pageDate &&
-            <time
-              className={ styles.date }
-              key={ pageDate.toISOString() }
-            >
-              { pageDate.locale("ja").format("YYYY/MM/DD dddd") }
-            </time>
-          }
-          {
-            <div
-              className={ styles.authors }
-            >
-              { authors }
-            </div>
-          }
-          {
-            head.image &&
-            <img
-              src={ coverDir + head.image }
-              className={ styles.cover }
-            />
-          }
-          </header>
-        }
-        footer={
-          <footer>
-          {
-            <ul className={ styles.sns }>
-              <li>
-                <FacebookButton
-                  url={ url }
-                  layout={ layout }
-                  appId={ appId }
-                />
-              </li>
-              <li>
-                <TwitterTweetButton
-                  text={ head.title }
-                />
-              </li>
-              <li><PocketButton /></li>
-              <li>
-                <HatenabookmarkButton url={ url } layout={ hatenaLayout } />
-              </li>
-            </ul>
-          }
-          </footer>
-        }
+      <Post
+        navigation={ this.postNavigation }
+        { ...this.props }
       />
     )
   }
 }
-
-Post.propTypes = {
-  head: PropTypes.object.isRequired,
-}
-
-export default Post

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -51,6 +51,7 @@ export const makeConfig = (config = {}) => {
           include: [
             path.resolve(__dirname, "scripts"),
             path.resolve(__dirname, "web_modules"),
+            path.resolve(__dirname, "node_modules", "react-icons"),
           ],
         },
 


### PR DESCRIPTION
# URL
- #46 

# 目的
各記事に対して前後記事へのリンクを追加

# やったこと
- https://github.com/thangngoc89/blog/tree/master/src/layouts/Post この辺を参考に実装
- flex-boxでスタイル設定
- 矢印アイコンはreact-iconsでfa-iconを利用

# 画像

## for PC
![1](https://cloud.githubusercontent.com/assets/1443118/18679665/a22c68d4-7f9b-11e6-829f-d36099c270d2.png)

## for SP
![2](https://cloud.githubusercontent.com/assets/1443118/18679666/a25404f2-7f9b-11e6-9c1c-831420dcbf72.png)
